### PR TITLE
Don't suggest spacing brace after opening parenthesis

### DIFF
--- a/lib/puppet-lint/plugins/check_manifest_whitespace_opening_brace.rb
+++ b/lib/puppet-lint/plugins/check_manifest_whitespace_opening_brace.rb
@@ -7,7 +7,7 @@ PuppetLint.new_check(:manifest_whitespace_opening_brace_before) do
       prev_code_token = prev_non_space_token(brace_token)
 
       next unless prev_token && prev_code_token
-      if %i[LBRACK LBRACE COLON COMMA COMMENT].include?(prev_code_token.type)
+      if %i[LPAREN LBRACK LBRACE COLON COMMA COMMENT].include?(prev_code_token.type)
         next
       end
       next unless tokens.index(prev_code_token) != tokens.index(brace_token) - 2 ||


### PR DESCRIPTION
This fixes #13 where inserting a space between an opening parenthesis and a hash argument is erroneously suggested.