### PR TITLE
Fix handling of nested left-braces

### DIFF
--- a/lib/puppet-lint/plugins/check_manifest_whitespace_opening_brace.rb
+++ b/lib/puppet-lint/plugins/check_manifest_whitespace_opening_brace.rb
@@ -11,9 +11,12 @@ PuppetLint.new_check(:manifest_whitespace_opening_brace_before) do
       next if %i[COMMA].include?(prev_code_token.type) && %i[INDENT NEWLINE].include?(prev_token.type)
       next if %i[COMMENT COLON].include?(prev_code_token.type)
 
-      if %i[LPAREN LBRACK LBRACE].include?(prev_code_token.type)
+      if %i[LPAREN LBRACK].include?(prev_code_token.type)
         next if tokens.index(prev_code_token) == tokens.index(brace_token) - 1
         next if tokens[tokens.index(prev_code_token)..tokens.index(brace_token)].collect(&:type).include?(:NEWLINE)
+      elsif %i[LBRACE].include?(prev_code_token.type)
+        next if tokens[tokens.index(prev_code_token)..tokens.index(brace_token)].collect(&:type).include?(:NEWLINE)
+        next if tokens.index(prev_code_token) == tokens.index(brace_token) - 2 && is_single_space(prev_token)
       else
         next unless tokens.index(prev_code_token) != tokens.index(brace_token) - 2 ||
                     !is_single_space(prev_token)
@@ -41,7 +44,7 @@ PuppetLint.new_check(:manifest_whitespace_opening_brace_before) do
       prev_token = prev_token.prev_token
     end
 
-    add_token(tokens.index(token), new_single_space) unless %i[LPAREN LBRACK LBRACE].include?(prev_code_token.type)
+    add_token(tokens.index(token), new_single_space) unless %i[LPAREN LBRACK].include?(prev_code_token.type)
   end
 end
 

--- a/spec/puppet-lint/plugins/manifest_whitespace_opening_brace_spec.rb
+++ b/spec/puppet-lint/plugins/manifest_whitespace_opening_brace_spec.rb
@@ -45,6 +45,78 @@ describe 'manifest_whitespace_opening_brace_before' do
     end
   end
 
+  context 'with a Hash-returning block' do
+    let(:code) do
+      <<~CODE
+        $result = $value.lest || { {} }
+      CODE
+    end
+
+    it 'detects no problems' do
+      expect(problems).to be_empty
+    end
+  end
+
+  context 'with a Hash-nested Hash' do
+    let(:code) do
+      <<~CODE
+        $result = { foo => {} }
+      CODE
+    end
+
+    it 'detects no problems' do
+      expect(problems).to be_empty
+    end
+  end
+
+  context 'with a Hash-nested Hash with a Hash key' do
+    let(:code) do
+      <<~CODE
+        $result = { { 'a' => 1 } => {} }
+      CODE
+    end
+
+    it 'detects no problems' do
+      expect(problems).to be_empty
+    end
+  end
+
+  context 'with a Hash-nested Hash with an empty Hash key' do
+    let(:code) do
+      <<~CODE
+        $result = { {} => {} }
+      CODE
+    end
+
+    it 'detects no problems' do
+      expect(problems).to be_empty
+    end
+  end
+
+  context 'with a Hash-returning block and no space' do
+    let(:code) do
+      <<~CODE
+        $result = $value.lest || {{} }
+      CODE
+    end
+
+    it 'detects one problems' do
+      expect(problems).to have(1).problem
+    end
+
+    context 'with fix enabled' do
+      before do
+        PuppetLint.configuration.fix = true
+      end
+
+      after do
+        PuppetLint.configuration.fix = false
+      end
+
+      it { expect(manifest).to eq("$result = $value.lest || { {} }\n") }
+    end
+  end
+
   context 'inside, inline with function' do
     let(:code) do
       <<~CODE


### PR DESCRIPTION
Previously, nested braces (such as might be used in syntax like `.lest || { {} }` would fail linting and get corrected to `.lest || {{} }`.  This commit adjusts the logic so that the former style is considered correct and the latter would be auto-corrected to the former.