### PR TITLE
Use new puppet-lint gem

### DIFF
--- a/puppet-lint-manifest_whitespace-check.gemspec
+++ b/puppet-lint-manifest_whitespace-check.gemspec
@@ -18,5 +18,5 @@ Gem::Specification.new do |spec|
 
   spec.required_ruby_version = Gem::Requirement.new('>= 2.7')
 
-  spec.add_dependency 'puppet-lint', '>= 4', '< 5'
+  spec.add_dependency 'puppetlabs-puppet-lint', '~> 5.0'
 end


### PR DESCRIPTION
Using the now-maintained puppetlabs-puppet-lint over puppet-lint